### PR TITLE
dont add link on html formatted text.

### DIFF
--- a/angular-sanitize.js
+++ b/angular-sanitize.js
@@ -574,7 +574,7 @@ angular.module('ngSanitize', []).provider('$sanitize', $SanitizeProvider);
  */
 angular.module('ngSanitize').filter('linky', ['$sanitize', function($sanitize) {
   var LINKY_URL_REGEXP =
-        /((ftp|https?):\/\/|(mailto:)?[A-Za-z0-9._%+-]+@)\S*[^\s.;,(){}<>]/,
+        /(((ftp|https?):\/\/)[^<>\]]+?(?![^<>\]]*([>]|<\/))|(mailto:)?[A-Za-z0-9._%+-]+@)\S*[^\s.;,(){}<>]/,
       MAILTO_REGEXP = /^mailto:/;
 
   return function(text, target) {


### PR DESCRIPTION
Hi guys, I wonder what you guys think of this change. Basically the change is to avoid adding the links on html formatted text. Ex:

```
Given Input 
1.  http://www.url.com
2. <a href="http://www.url.com">my link</a>

Original Output
1. <a href="http://www.url.com">http://www.url.com</a>
2. "<a href=""<a href="http://www.url.com">http://www.url.com</a>"">my link</a>

With this fix this one changes to the following Output
1. <a href="http://www.url.com">http://www.url.com</a>
2. <a href="http://www.url.com">my link</a>
```

Use cases:

Some of the dynamic values we get from the the backend are already formatted. We would like the additional feature of allowing the html formatted to be used as non-formatted to be formatted or linky + html tag support.

Here is the Regex test I used.
http://regex101.com/r/iE7wF5

What do you guys think?
Thanks.
