### PR TITLE
Updated package.json for JSPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "http://angularjs.org",
   "jspm": {
+    "main": "index",
     "shim": {
       "angular-sanitize": {
         "deps": ["angular"]


### PR DESCRIPTION
JSPM gave back angular-sanitize.js, but it should be index.js so the export is the module's name, not an empty object.
